### PR TITLE
Implement toggle for scrolling and add config for a viewport-offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ Simply copy the `user/plugins/markdown-collapsible/markdown-collapsible.yaml` in
 ```
 enabled: true
 built_in_css: true
+do_autoscroll: true
+scroll_offset: 0
 ```
+
+## Automatic scroll-to-content
+The default behaviour is to smooth-scroll the viewport to the top of the new content when a collapsible section is opened. To disable this, set the `do_autoscroll` configuration item to `false`.
+
+An optional viewport-top offset (in pixels) can be specified to support themes with a sticky header or other visual effects.
 
 # Examples
 
@@ -60,7 +67,7 @@ You will output the following HTML:
 
 If you want an accordion style (that is, only a single section is opened at a time), you'll use the special syntax:
 `!>[name] My section`.
-All sections declared with the same name will fold/unfold so only one is visible at a time.
+All sections declared with the same name will fold/unfold so only one is visible at a time (i.e. an accordion).
 
 
 Example usage in Grav [here](https://blog.cyril.by/en/documentation/emqtt5-doc/emqtt5)

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -25,7 +25,7 @@ form:
 
     built_in_css:
       type: toggle
-      label: Use built in CSS
+      label: Use built-in CSS
       highlight: 1
       default: 1
       options:
@@ -34,4 +34,23 @@ form:
       validate:
         type: bool
 
+    do_autoscroll:
+      type: toggle
+      label: Scroll to content on expand
+      highlight: 1
+      default: 1
+      options:
+        1: Yes
+        0: No
+      validate:
+        type: bool
 
+    scroll_offset:
+      type: text
+      size: x-small
+      label: Viewport top offset on scroll
+      append: px
+      default: 0
+      validate:
+        type: int
+        min: 0

--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -1,6 +1,10 @@
 document.addEventListener("DOMContentLoaded", function(event){
   document.querySelectorAll("label.collapsible").forEach(function(el) {
-    el.addEventListener("click", function(ev) { setTimeout(function(){ev.target.scrollIntoView({behavior: "smooth"})}, 100)});
+    el.addEventListener("click", function(ev) {
+      if(!el.classList.contains('no-scroll')){
+        setTimeout(function(){ev.target.scrollIntoView({behavior: "smooth"})}, 100)
+      }
+    });
     document.getElementById(el.getAttribute("for")).addEventListener("click", function(ev) {
       if (ev.target.previous) ev.target.checked = false;
       if (ev.target.checked) document.querySelectorAll("input.collapsible").forEach(function(i) { i.previous = false });

--- a/markdown-collapsible.php
+++ b/markdown-collapsible.php
@@ -16,15 +16,14 @@ class MarkdownCollapsiblePlugin extends Plugin
     {
         return [
             'onMarkdownInitialized' => ['onMarkdownInitialized', 0],
-            'onTwigSiteVariables'   => ['onTwigSiteVariables', 0]
+            'onTwigSiteVariables'   => ['onTwigSiteVariables', 0],
+            'onAssetsInitialized'   => ['onAssetsInitialized', 0]
         ];
     }
 
     public function onMarkdownInitialized(Event $event)
     {
         $markdown = $event['markdown'];
-
-        
 
         $markdown->addBlockType('!', 'Collapsible', false, false);
 
@@ -34,6 +33,7 @@ class MarkdownCollapsiblePlugin extends Plugin
                 $offset = $this->config->get('plugins.markdown-collapsible.scroll_offset');  
             }
 
+            
             if (preg_match('/^!>(\[(\w[\w-]*)\])?\s*(.*)$/', $Line['text'], $matches))
             {
                 $name = $matches[2];
@@ -50,7 +50,7 @@ class MarkdownCollapsiblePlugin extends Plugin
 
                 $Block = array(
                     'name' => 'input',
-                    'markup' => '<input class="collapsible" id="'.$id.'" '.($name ? ' type="radio" name="'.$name.'"' : ' type="checkbox"').'><label class="collapsible'.(!$do_autoscroll ? ' no-scroll' : '').'" for="'.$id.'"'. ($do_autoscroll ? 'style="scroll-margin:'.$offset.'px"' : '') .'>'.$text.'</label><div class="collapsible">',
+                    'markup' => '<input class="collapsible" id="'.$id.'" '.($name ? ' type="radio" name="'.$name.'"' : ' type="checkbox"').'><label class="collapsible'.(!$do_autoscroll ? ' no-scroll' : '').'" for="'.$id.'">'.$text.'</label><div class="collapsible">',
                 );
                 return $Block;
             }
@@ -74,12 +74,20 @@ class MarkdownCollapsiblePlugin extends Plugin
             }
         };
     }
+    
+    public function onAssetsInitialized()
+    {
+        $offset = $this->config->get('plugins.markdown-collapsible.scroll_offset');
+        if ($this->config->get('plugins.markdown-collapsible.do_autoscroll') && $offset > 0 )
+        {
+            $this->grav['assets']->addInlineCss('label.collapsible { scroll-margin: '.$offset.'px; }');
+        }
+    }
 
     public function onTwigSiteVariables()
     {
         if ($this->config->get('plugins.markdown-collapsible.built_in_css')) {
-            $this->grav['assets']
-                ->add('plugin://markdown-collapsible/assets/collapsible.css');
+            $this->grav['assets']->add('plugin://markdown-collapsible/assets/collapsible.css');
         }
         $this->grav['assets']->add('plugin://markdown-collapsible/js/collapsible.js');
     }

--- a/markdown-collapsible.php
+++ b/markdown-collapsible.php
@@ -24,9 +24,16 @@ class MarkdownCollapsiblePlugin extends Plugin
     {
         $markdown = $event['markdown'];
 
+        
+
         $markdown->addBlockType('!', 'Collapsible', false, false);
 
         $markdown->blockCollapsible = function($Line) {
+            $do_autoscroll = $this->config->get('plugins.markdown-collapsible.do_autoscroll');
+            if($do_autoscroll){
+                $offset = $this->config->get('plugins.markdown-collapsible.scroll_offset');  
+            }
+
             if (preg_match('/^!>(\[(\w[\w-]*)\])?\s*(.*)$/', $Line['text'], $matches))
             {
                 $name = $matches[2];
@@ -43,7 +50,7 @@ class MarkdownCollapsiblePlugin extends Plugin
 
                 $Block = array(
                     'name' => 'input',
-                    'markup' => '<input class="collapsible" id="'.$id.'" '.($name ? ' type="radio" name="'.$name.'"' : ' type="checkbox"').'><label class="collapsible" for="'.$id.'">'.$text.'</label><div class="collapsible">',
+                    'markup' => '<input class="collapsible" id="'.$id.'" '.($name ? ' type="radio" name="'.$name.'"' : ' type="checkbox"').'><label class="collapsible'.(!$do_autoscroll ? ' no-scroll' : '').'" for="'.$id.'"'. ($do_autoscroll ? 'style="scroll-margin:'.$offset.'px"' : '') .'>'.$text.'</label><div class="collapsible">',
                 );
                 return $Block;
             }

--- a/markdown-collapsible.yaml
+++ b/markdown-collapsible.yaml
@@ -1,3 +1,5 @@
 enabled: true
 built_in_css: true
+do_autoscroll: true
+scroll_offset: 0
 level_classes: [collapsible]


### PR DESCRIPTION
This PR adds two features to the plugin with admin-console UI:
* Can toggle off the scroll-to-content behaviour
* Can specify an offset for the scroll-to-content that positions the viewport better for sticky headers and such.

This is my first time working with Grav under the hood, so please check my code for anything I've missed that needs to be done.